### PR TITLE
chore: made copyright headers consistant

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -1,4 +1,4 @@
-// This file Copyright © Transmission authors and contributors.
+// This file Copyright © 2006-2023 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/gtk/FilterListModel.h
+++ b/gtk/FilterListModel.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2023 Mnemosyne LLC.
+// This file Copyright © 2023-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/FilterListModel.hh
+++ b/gtk/FilterListModel.hh
@@ -1,4 +1,4 @@
-// This file Copyright © 2023 Mnemosyne LLC.
+// This file Copyright © 2023-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/Flags.h
+++ b/gtk/Flags.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2022 Mnemosyne LLC.
+// This file Copyright © 2022-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/GtkCompat.h
+++ b/gtk/GtkCompat.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2022 Mnemosyne LLC.
+// This file Copyright © 2022-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/ListModelAdapter.h
+++ b/gtk/ListModelAdapter.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2022 Mnemosyne LLC.
+// This file Copyright © 2022-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/PathButton.cc
+++ b/gtk/PathButton.cc
@@ -1,4 +1,4 @@
-// This file Copyright © 2022 Mnemosyne LLC.
+// This file Copyright © 2022-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/PathButton.h
+++ b/gtk/PathButton.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2022 Mnemosyne LLC.
+// This file Copyright © 2022-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/Prefs.cc
+++ b/gtk/Prefs.cc
@@ -1,4 +1,4 @@
-// This file copyright (C) Transmission authors and contributors.
+// This file Copyright © Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/gtk/Prefs.h
+++ b/gtk/Prefs.h
@@ -1,4 +1,4 @@
-// This file copyright (C) 2005-2022 Transmission authors and contributors.
+// This file Copyright © 2005-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -1,4 +1,4 @@
-// Copyright © Transmission authors and contributors.
+// This file Copyright © 2021-2023 Transmission authors and contributors.
 // This file is licensed under the MIT (SPDX: MIT) license,
 // A copy of this license can be found in licenses/ .
 

--- a/gtk/Session.h
+++ b/gtk/Session.h
@@ -1,4 +1,4 @@
-// Copyright © Transmission authors and contributors.
+// This file Copyright © 2021-2023 Transmission authors and contributors.
 // This file is licensed under the MIT (SPDX: MIT) license,
 // A copy of this license can be found in licenses/ .
 

--- a/gtk/SortListModel.h
+++ b/gtk/SortListModel.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2023 Mnemosyne LLC.
+// This file Copyright © 2023-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/SortListModel.hh
+++ b/gtk/SortListModel.hh
@@ -1,4 +1,4 @@
-// This file Copyright © 2023 Mnemosyne LLC.
+// This file Copyright © 2023-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/Torrent.h
+++ b/gtk/Torrent.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2022 Mnemosyne LLC.
+// This file Copyright © 2022-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -1,4 +1,4 @@
-// This file Copyright 2021-2022 Mnemosyne LLC.
+// This file Copyright © 2021-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -1,4 +1,4 @@
-// Copyright © Transmission authors and contributors.
+// This file Copyright © 2006-2023 Transmission authors and contributors.
 // This file is licensed under the MIT (SPDX: MIT) license,
 // A copy of this license can be found in licenses/ .
 

--- a/libtransmission/stats.cc
+++ b/libtransmission/stats.cc
@@ -1,4 +1,4 @@
-// This file Copyright 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/stats.h
+++ b/libtransmission/stats.h
@@ -1,4 +1,4 @@
-// This file Copyright 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/timer-ev.cc
+++ b/libtransmission/timer-ev.cc
@@ -1,4 +1,4 @@
-// This file Copyright 2022 Mnemosyne LLC.
+// This file Copyright © 2022-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/timer-ev.h
+++ b/libtransmission/timer-ev.h
@@ -1,4 +1,4 @@
-// This file Copyright 2022 Mnemosyne LLC.
+// This file Copyright © 2022-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/timer.h
+++ b/libtransmission/timer.h
@@ -1,4 +1,4 @@
-// This file Copyright 2022 Mnemosyne LLC.
+// This file Copyright © 2022-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/torrents.cc
+++ b/libtransmission/torrents.cc
@@ -1,4 +1,4 @@
-// This file Copyright © 2022 Mnemosyne LLC.
+// This file Copyright © 2022-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/torrents.h
+++ b/libtransmission/torrents.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2022 Mnemosyne LLC.
+// This file Copyright © 2022-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -1,4 +1,4 @@
-// This file Copyright 2022 Mnemosyne LLC.
+// This file Copyright © 2022-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/tr-lpd.h
+++ b/libtransmission/tr-lpd.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2022 Mnemosyne LLC.
+// This file Copyright © 2022-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/tr-popcount.h
+++ b/libtransmission/tr-popcount.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2022 Mnemosyne LLC.
+// This file Copyright © 2022-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2022 Mnemosyne LLC.
+// This file Copyright © 2022-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -1,4 +1,4 @@
-// This file Copyright © 2010 Juliusz Chroboczek.
+// This file Copyright © 2010-2023 Juliusz Chroboczek.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/libtransmission/tr-utp.cc
+++ b/libtransmission/tr-utp.cc
@@ -1,4 +1,4 @@
-// This file Copyright © 2010 Juliusz Chroboczek.
+// This file Copyright © 2010-2023 Juliusz Chroboczek.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/libtransmission/tr-utp.h
+++ b/libtransmission/tr-utp.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2010 Juliusz Chroboczek.
+// This file Copyright © 2010-2023 Juliusz Chroboczek.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -1,4 +1,4 @@
-// This file Copyright © Transmission authors and contributors.
+// This file Copyright © 2006-2023 Transmission authors and contributors.
 // It may be used under the 3-Clause BSD (SPDX: BSD-3-Clause),
 // GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.

--- a/libtransmission/utils-ev.cc
+++ b/libtransmission/utils-ev.cc
@@ -1,4 +1,4 @@
-// This file Copyright © 2022 Mnemosyne LLC.
+// This file Copyright © 2022-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/utils-ev.h
+++ b/libtransmission/utils-ev.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2022 Mnemosyne LLC.
+// This file Copyright © 2022-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/variant-converters.cc
+++ b/libtransmission/variant-converters.cc
@@ -1,4 +1,4 @@
-// This file Copyright © 2022 Mnemosyne LLC.
+// This file Copyright © 2022-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/macosx/CocoaCompatibility.h
+++ b/macosx/CocoaCompatibility.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2022 Transmission authors and contributors.
+// This file Copyright © 2022-2023 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/GroupPopUpButtonCell.h
+++ b/macosx/GroupPopUpButtonCell.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2022 Transmission authors and contributors.
+// This file Copyright © 2022-2023 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/GroupPopUpButtonCell.mm
+++ b/macosx/GroupPopUpButtonCell.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2022 Transmission authors and contributors.
+// This file Copyright © 2022-2023 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/GroupTextCell.h
+++ b/macosx/GroupTextCell.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2022 Transmission authors and contributors.
+// This file Copyright © 2022-2023 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/GroupTextCell.mm
+++ b/macosx/GroupTextCell.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2022 Transmission authors and contributors.
+// This file Copyright © 2022-2023 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/NSDataAdditions.h
+++ b/macosx/NSDataAdditions.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2022 Transmission authors and contributors.
+// This file Copyright © 2022-2023 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/NSDataAdditions.mm
+++ b/macosx/NSDataAdditions.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2022 Transmission authors and contributors.
+// This file Copyright © 2022-2023 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PriorityPopUpButtonCell.h
+++ b/macosx/PriorityPopUpButtonCell.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2022 Transmission authors and contributors.
+// This file Copyright © 2022-2023 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PriorityPopUpButtonCell.mm
+++ b/macosx/PriorityPopUpButtonCell.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2022 Transmission authors and contributors.
+// This file Copyright © 2022-2023 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/SparkleProxy.mm
+++ b/macosx/SparkleProxy.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2022 Transmission authors and contributors.
+// This file Copyright © 2022-2023 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/web/src/about-dialog.js
+++ b/web/src/about-dialog.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+/* @license This file Copyright © 2020-2022 Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */

--- a/web/src/action-manager.js
+++ b/web/src/action-manager.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+/* @license This file Copyright © 2020-2022 Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */

--- a/web/src/alert-dialog.js
+++ b/web/src/alert-dialog.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+/* @license This file Copyright © 2020-2022 Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */

--- a/web/src/context-menu.js
+++ b/web/src/context-menu.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+/* @license This file Copyright © 2020-2022 Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */

--- a/web/src/file-row.js
+++ b/web/src/file-row.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+/* @license This file Copyright © 2020-2022 Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */

--- a/web/src/formatter.js
+++ b/web/src/formatter.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+/* @license This file Copyright © 2020-2022 Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+/* @license This file Copyright © 2020-2022 Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */

--- a/web/src/labels-dialog.js
+++ b/web/src/labels-dialog.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+/* @license This file Copyright © 2020-2022 Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+/* @license This file Copyright © 2020-2022 Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */

--- a/web/src/move-dialog.js
+++ b/web/src/move-dialog.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+/* @license This file Copyright © 2020-2022 Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */

--- a/web/src/notifications.js
+++ b/web/src/notifications.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+/* @license This file Copyright © 2020-2022 Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */

--- a/web/src/open-dialog.js
+++ b/web/src/open-dialog.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+/* @license This file Copyright © 2020-2022 Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */

--- a/web/src/overflow-menu.js
+++ b/web/src/overflow-menu.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+/* @license This file Copyright © 2020-2022 Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */

--- a/web/src/prefs-dialog.js
+++ b/web/src/prefs-dialog.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+/* @license This file Copyright © 2020-2022 Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */

--- a/web/src/prefs.js
+++ b/web/src/prefs.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+/* @license This file Copyright © 2020-2022 Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */

--- a/web/src/remote.js
+++ b/web/src/remote.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright © Charles Kerr, Dave Perrett, Malcolm Jarvis and Bruno Bierbaumer
+/* @license This file Copyright © 2020-2023 Charles Kerr, Dave Perrett, Malcolm Jarvis and Bruno Bierbaumer
    It may be used under GPLv2 (SPDX: GPL-2.0-only).
    License text can be found in the licenses/ folder. */
 

--- a/web/src/remove-dialog.js
+++ b/web/src/remove-dialog.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+/* @license This file Copyright © 2020-2022 Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */

--- a/web/src/rename-dialog.js
+++ b/web/src/rename-dialog.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+/* @license This file Copyright © 2020-2022 Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */

--- a/web/src/shortcuts-dialog.js
+++ b/web/src/shortcuts-dialog.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+/* @license This file Copyright © 2020-2022 Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */

--- a/web/src/statistics-dialog.js
+++ b/web/src/statistics-dialog.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+/* @license This file Copyright © 2020-2022 Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */

--- a/web/src/torrent-row.js
+++ b/web/src/torrent-row.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+/* @license This file Copyright © 2020-2022 Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+/* @license This file Copyright © 2020-2022 Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright © Charles Kerr, Dave Perrett, Malcolm Jarvis and Bruno Bierbaumer
+/* @license This file Copyright © 2020-2023 Charles Kerr, Dave Perrett, Malcolm Jarvis and Bruno Bierbaumer
    It may be used under GPLv2 (SPDX: GPL-2.0-only).
    License text can be found in the licenses/ folder. */
 

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+/* @license This file Copyright © 2020-2022 Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */


### PR DESCRIPTION
Opted for a standard "This file Copyright © 20XX-20XX" in the headers (as per #2463) in preparation for an automated copyright updating github action.